### PR TITLE
Add a simple integration test

### DIFF
--- a/auto-module-sample/build.gradle
+++ b/auto-module-sample/build.gradle
@@ -37,10 +37,18 @@ android {
         targetSdkVersion 23
         versionCode 1
         versionName "1.0"
+
+        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_7
         targetCompatibility JavaVersion.VERSION_1_7
+    }
+}
+
+configurations.all {
+    resolutionStrategy {
+        force 'com.android.support:support-annotations:23.0.1'
     }
 }
 
@@ -51,4 +59,8 @@ dependencies {
     apt 'com.squareup.dagger:dagger-compiler:1.2.2'
     compile project(':auto-module')
     apt project(':auto-module-processor')
+
+    androidTestCompile 'com.android.support.test:runner:0.3'
+    androidTestCompile 'com.android.support.test:rules:0.3'
+    androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2'
 }

--- a/auto-module-sample/src/androidTest/java/com/jaynewstrom/autoModuleSample/MainActivityTest.java
+++ b/auto-module-sample/src/androidTest/java/com/jaynewstrom/autoModuleSample/MainActivityTest.java
@@ -1,0 +1,23 @@
+package com.jaynewstrom.autoModuleSample;
+
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+
+@RunWith(AndroidJUnit4.class)
+public final class MainActivityTest {
+
+    @Rule public ActivityTestRule<MainActivity> rule = new ActivityTestRule<>(MainActivity.class);
+
+    @Test public void testInjectionWorks() {
+        onView(withId(R.id.text_view)).check(matches(withText("It's injected")));
+    }
+}


### PR DESCRIPTION
Closes #2 

This ensures that the dagger code generator runs, and everything is valid when it is needed at runtime.
